### PR TITLE
Fix undef argv and options typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
 								"description": "Use `bundle exec` to run rdebug-ide. Enable this option if you have used bundle install --path with rdebug-ide as a bundled gem.",
 								"default": false
 							},
-							"pathToBundle": {
+							"pathToBundler": {
 								"type": "string",
 								"description": "If you use the `useBunder` option, and `bundle` is not in your path, provide the absolute path to `bundle` (eg. \"/usr/bin/bundle\" )",
 								"default": "bundle"

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -195,7 +195,7 @@ export class RubyProcess extends EventEmitter {
                 }
             }
 
-            this.debugprocess = childProcess.spawn(runtimeExecutable, [...runtimeArgs, args.program, ...args.args||[]], {cwd: processCwd});
+            this.debugprocess = childProcess.spawn(runtimeExecutable, [...runtimeArgs, args.program, ...args.args || []], {cwd: processCwd});
 
             // redirect output to debug console
             this.debugprocess.stdout.on('data', (data: Buffer) => {

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -195,7 +195,7 @@ export class RubyProcess extends EventEmitter {
                 }
             }
 
-            this.debugprocess = childProcess.spawn(runtimeExecutable, [...runtimeArgs, args.program, ...args.args], {cwd: processCwd});
+            this.debugprocess = childProcess.spawn(runtimeExecutable, [...runtimeArgs, args.program, ...args.args||[]], {cwd: processCwd});
 
             // redirect output to debug console
             this.debugprocess.stdout.on('data', (data: Buffer) => {


### PR DESCRIPTION
Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)

If no arguments are passed in the option file `args.args` is unset and with the ... operator the value `undefined` is appended to the array. Spawn then rewrites this to the string `"undefined"`.

This change extends with an empty array instead if `args.args` is undefined.